### PR TITLE
Fix internal/external  validation when no categorical metadata

### DIFF
--- a/workflow/scripts/plot_indices.R
+++ b/workflow/scripts/plot_indices.R
@@ -26,6 +26,11 @@ for (idx in indices) {
   #     scores <- read.csv(file.path(index_paths[[idx]]), row.names = 1)
   scores <- data.frame(fread(file.path(index_paths[[idx]]), header = TRUE), row.names = 1)
 
+  if (ncol(scores) == 0) {
+    warning(paste("Skipping", idx, "plot because the index table has no score columns."))
+    next
+  }
+
   # scale internal indices, add seperator and reorder columns (max/sep/min)
   if (length(indices) == 1) {
     scores <- as.data.frame(scale(scores))

--- a/workflow/scripts/validation_external.py
+++ b/workflow/scripts/validation_external.py
@@ -45,6 +45,12 @@ for variable in metadata.columns:
         # subset for categorical data
 categorical_metadata = metadata.loc[:, meta_cat]
 
+if categorical_metadata.shape[1] == 0:
+    print(
+        "No categorical metadata columns found; external cluster validation "
+        "outputs will contain no score columns."
+    )
+
 # Ensure that the clustering results and categorical metadata have the same indices
 # fix metadata indices if they do not agree with data as they come from outside the workflow (e.g., R)
 if not (set(clustering_results.index) == set(categorical_metadata.index)):

--- a/workflow/scripts/validation_internal.R
+++ b/workflow/scripts/validation_internal.R
@@ -84,10 +84,12 @@ for (col in colnames(metadata)) {
 metadata <- metadata[, !(colnames(metadata) %in% na_cols), drop = FALSE]
 # add categorical metadata to clustering results with prefix "metadata_"
 metadata_cat <- metadata[, sapply(metadata, function(x) !is.numeric(x)), drop = FALSE]
-# Convert all categorical columns to integer
-metadata_cat[colnames(metadata_cat)] <- lapply(metadata_cat[colnames(metadata_cat)], function(x) as.integer(factor(x)))
-colnames(metadata_cat) <- paste0("metadata_", colnames(metadata_cat))
-clusterings <- cbind(clusterings, metadata_cat)
+if (ncol(metadata_cat) > 0) {
+  # Convert all categorical columns to integer
+  metadata_cat[colnames(metadata_cat)] <- lapply(metadata_cat[colnames(metadata_cat)], function(x) as.integer(factor(x)))
+  colnames(metadata_cat) <- paste0("metadata_", colnames(metadata_cat))
+  clusterings <- cbind(clusterings, metadata_cat)
+}
 
 ### determine internal indices using clusterCrit
 indices_df <- data.frame(matrix(ncol = 1, nrow = ncol(clusterings), dimnames = list(colnames(clusterings), internal_index)))


### PR DESCRIPTION
Small changes to make the code robust to no categorical metadata.
* external validation does not outputs scors, so plot_indices is skipped
* internal validation does not add metadata clusters


Related to issue #98 (can close it with this PR)
PS: my test metadata was not discretized because the data were not integers